### PR TITLE
Add retry for curl steps

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,10 +16,10 @@ runs:
       shell: bash
       id: cargo
     - name: Download ${{inputs.bin || inputs.crate}}
-      run: curl --output ${{steps.cargo.outputs.dir}}/${{inputs.bin || inputs.crate}} https://github.com/dtolnay/install/releases/download/${{inputs.crate}}/${{inputs.bin || inputs.crate}} --location --silent --show-error --fail
+      run: curl --output ${{steps.cargo.outputs.dir}}/${{inputs.bin || inputs.crate}} https://github.com/dtolnay/install/releases/download/${{inputs.crate}}/${{inputs.bin || inputs.crate}} --location --silent --show-error --fail --retry 5
       shell: bash
     - name: Download ${{inputs.bin || inputs.crate}}.sig
-      run: curl --output ${{runner.temp}}/${{inputs.bin || inputs.crate}}.sig https://github.com/dtolnay/install/releases/download/${{inputs.crate}}/${{inputs.bin || inputs.crate}}.sig --location --silent --show-error --fail
+      run: curl --output ${{runner.temp}}/${{inputs.bin || inputs.crate}}.sig https://github.com/dtolnay/install/releases/download/${{inputs.crate}}/${{inputs.bin || inputs.crate}}.sig --location --silent --show-error --fail --retry 5
       shell: bash
     - name: Retrieve public key of signing key
       run: gpg --output ${{runner.temp}}/signing-key.gpg --yes --dearmor ${{github.action_path}}/signing-key.asc


### PR DESCRIPTION
I just had a CI job fail with:

```console
Run curl --output /home/runner/work/_temp/cargo-outdated.sig https://github.com/dtolnay/install/releases/download/cargo-outdated/cargo-outdated.sig --location --silent --show-error --fail
curl: (22) The requested URL returned error: 503 
Error: Process completed with exit code 22.
```

Hopefully this kind of thing is a transient glitch. Other jobs around the same time succeeded.