### PR TITLE
Change target_commitish from github.ref to github.sha

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{inputs.crate}}
-          target_commitish: ${{github.ref}}
+          target_commitish: ${{github.sha}}
           files: |
             ${{steps.which.outputs.which}}
             ${{inputs.bin || inputs.crate}}.sig


### PR DESCRIPTION
See https://github.com/softprops/action-gh-release/issues/213. I am getting the same failures recently: _"tag_name is not a valid tag"_. Strangely it used to work.