### PR TITLE
Checkout and install from repo, instead of --git

### DIFF
--- a/.github/workflows/buck2.yml
+++ b/.github/workflows/buck2.yml
@@ -10,7 +10,8 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       crate: buck2
-      git: https://github.com/facebookincubator/buck2
+      git: facebookincubator/buck2
+      path: cli
     permissions:
       contents: write
     secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,10 @@ on:
       git:
         required: false
         type: string
-      branch:
+      ref:
+        required: false
+        type: string
+      path:
         required: false
         type: string
     secrets:
@@ -28,8 +31,15 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{inputs.git}}
+          ref: ${{inputs.ref}}
+          path: ${{inputs.crate}}
+        if: inputs.git
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo install --force ${{inputs.crate}} --bin ${{inputs.bin || inputs.crate}} ${{inputs.git && format('--git={0}', inputs.git) || ''}} ${{inputs.branch && format('--branch={0}', inputs.branch) || ''}}
+      - run: cargo install --force ${{inputs.git && format('--path={0}', inputs.path || '.') || inputs.crate}} --bin ${{inputs.bin || inputs.crate}}
+        working-directory: ${{inputs.git && inputs.crate || '.'}}
       - id: which
         run: echo "which=$(which ${{inputs.bin || inputs.crate}})" >> $GITHUB_OUTPUT
       - id: version

--- a/.github/workflows/rustup-toolchain-install-master.yml
+++ b/.github/workflows/rustup-toolchain-install-master.yml
@@ -10,8 +10,8 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       crate: rustup-toolchain-install-master
-      git: https://github.com/dtolnay-contrib/rustup-toolchain-install-master
-      branch: nodefault
+      git: dtolnay-contrib/rustup-toolchain-install-master
+      ref: nodefault
     permissions:
       contents: write
     secrets: inherit


### PR DESCRIPTION
Building straight from the repo is what most projects are set up to accommodate. Cargo install's `--git` flag has many more failure modes.