### PR TITLE
Update softprops/action-gh-release action to v2 (node20)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       - run: git tag -d ${{inputs.crate}} || true
       - run: git tag ${{inputs.crate}}
       - run: git push origin tag ${{inputs.crate}} --force
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{inputs.crate}}
           target_commitish: ${{github.ref}}


### PR DESCRIPTION
Release notes: https://github.com/softprops/action-gh-release/releases/tag/v2.0.0

This should resolve warnings like the following.

![image](https://github.com/dtolnay/install/assets/1940490/c554df16-e93a-4688-96f0-77dcfea937a0)
