### PR TITLE
Delete gpg-based verification in favor of attestations

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,15 +24,6 @@ runs:
     - name: Download ${{steps.inputs.outputs.bin}}
       run: curl --output ${{steps.cargo.outputs.dir}}/${{steps.inputs.outputs.bin}} https://github.com/dtolnay/install/releases/download/${{steps.inputs.outputs.crate}}/${{steps.inputs.outputs.bin}} --location --silent --show-error --fail --retry 5
       shell: bash
-    - name: Download ${{steps.inputs.outputs.bin}}.sig
-      run: curl --output ${{runner.temp}}/${{steps.inputs.outputs.bin}}.sig https://github.com/dtolnay/install/releases/download/${{steps.inputs.outputs.crate}}/${{steps.inputs.outputs.bin}}.sig --location --silent --show-error --fail --retry 5
-      shell: bash
-    - name: Retrieve public key of signing key
-      run: gpg --output ${{runner.temp}}/signing-key.gpg --yes --dearmor ${{github.action_path}}/signing-key.asc
-      shell: bash
-    - name: Verify gpg signature
-      run: gpg --no-default-keyring --keyring ${{runner.temp}}/signing-key.gpg --trusted-key 830334D6A6010C41 --verify ${{runner.temp}}/${{steps.inputs.outputs.bin}}.sig ${{steps.cargo.outputs.dir}}/${{steps.inputs.outputs.bin}}
-      shell: bash
     - name: Verify artifact attestation
       run: gh attestation verify --owner dtolnay ${{steps.cargo.outputs.dir}}/${{steps.inputs.outputs.bin}}
       env:


### PR DESCRIPTION
This is superseded by https://github.com/dtolnay/install/pull/22.