### PR TITLE
Sort permissions

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -13,6 +13,6 @@ jobs:
       crate: bindgen-cli
       bin: bindgen
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/buckle.yml
+++ b/.github/workflows/buckle.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: buckle
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,9 @@ jobs:
     name: ${{inputs.crate}}
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cargo-afl.yml
+++ b/.github/workflows/cargo-afl.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: cargo-afl
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/cargo-bloat.yml
+++ b/.github/workflows/cargo-bloat.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: cargo-bloat
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/cargo-docs-rs.yml
+++ b/.github/workflows/cargo-docs-rs.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: cargo-docs-rs
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/cargo-expand.yml
+++ b/.github/workflows/cargo-expand.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: cargo-expand
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/cargo-fuzz.yml
+++ b/.github/workflows/cargo-fuzz.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: cargo-fuzz
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/cargo-llvm-lines.yml
+++ b/.github/workflows/cargo-llvm-lines.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: cargo-llvm-lines
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/cargo-outdated.yml
+++ b/.github/workflows/cargo-outdated.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: cargo-outdated
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/cargo-tally.yml
+++ b/.github/workflows/cargo-tally.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: cargo-tally
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/cargo-unlock.yml
+++ b/.github/workflows/cargo-unlock.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: cargo-unlock
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/cargo-web.yml
+++ b/.github/workflows/cargo-web.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: cargo-web
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/cbindgen.yml
+++ b/.github/workflows/cbindgen.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: cbindgen
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/cxxbridge-cmd.yml
+++ b/.github/workflows/cxxbridge-cmd.yml
@@ -13,6 +13,6 @@ jobs:
       crate: cxxbridge-cmd
       bin: cxxbridge
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/dircnt.yml
+++ b/.github/workflows/dircnt.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: dircnt
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/dotslash.yml
+++ b/.github/workflows/dotslash.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: dotslash
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/faketty.yml
+++ b/.github/workflows/faketty.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: faketty
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/honggfuzz.yml
+++ b/.github/workflows/honggfuzz.yml
@@ -13,6 +13,6 @@ jobs:
       crate: honggfuzz
       bin: cargo-hfuzz
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: mdbook
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/reindeer.yml
+++ b/.github/workflows/reindeer.yml
@@ -13,6 +13,6 @@ jobs:
       crate: reindeer
       git: facebookincubator/reindeer
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/rustup-toolchain-install-master.yml
+++ b/.github/workflows/rustup-toolchain-install-master.yml
@@ -14,6 +14,6 @@ jobs:
       git: dtolnay-contrib/rustup-toolchain-install-master
       ref: nodefault
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/sha1dir.yml
+++ b/.github/workflows/sha1dir.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: sha1dir
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       crate: star-history
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write

--- a/.github/workflows/taplo-cli.yml
+++ b/.github/workflows/taplo-cli.yml
@@ -14,6 +14,6 @@ jobs:
       bin: taplo
       locked: true
     permissions:
-      id-token: write
-      contents: write
       attestations: write
+      contents: write
+      id-token: write


### PR DESCRIPTION
They're sorted in both of these pages of documentation:

- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token

- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions

The odd order in https://github.com/dtolnay/install/commit/ef622f5ab60fd544ba3491568025b1bb677f2fb7 came from here:

- https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#generating-artifact-attestations-for-your-builds

but I cannot tell what motivates that particular order.